### PR TITLE
feature: add users

### DIFF
--- a/.github/workflows/deploy-env-and-docker-compose.yml
+++ b/.github/workflows/deploy-env-and-docker-compose.yml
@@ -77,6 +77,12 @@ jobs:
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET_PROD }}
           SPOTIFY_SCOPES: ${{ secrets.SPOTIFY_SCOPES }}
           TMTA_USERNAME: ${{ secrets.TMTA_USERNAME }}
+          SUPERADMIN_USERNAME: ${{ secrets.SUPERADMIN_USERNAME }}
+          SUPERADMIN_EMAIL: ${{ vars.SUPERADMIN_EMAIL }}
+          SUPERADMIN_PASSWORD: ${{ secrets.SUPERADMIN_PASSWORD }}
+          DEMO_USERNAME: ${{ secrets.DEMO_USERNAME }}
+          DEMO_EMAIL: ${{ vars.DEMO_EMAIL }}
+          DEMO_PASSWORD: ${{ secrets.DEMO_PASSWORD }}
         run: |
           bash scripts/check-workflow-env.sh \
             DOMAIN_NAME \
@@ -127,7 +133,13 @@ jobs:
             SPOTIFY_CLIENT_ID \
             SPOTIFY_CLIENT_SECRET \
             TMTA_USERNAME \
-            
+            SUPERADMIN_USERNAME \
+            SUPERADMIN_EMAIL \
+            SUPERADMIN_PASSWORD \
+            DEMO_USERNAME \
+            DEMO_EMAIL \
+            DEMO_PASSWORD \
+
   set-env-variables-on-server:
     name: Set env vars
     needs: [check-vars-and-secrets]
@@ -196,6 +208,12 @@ jobs:
             echo 'AFP_POST_ENDPOINT=${{ vars.AFP_POST_ENDPOINT }}' >> ${{ env.API_ENV_FILE }} &&
 
             echo 'TMTA_USERNAME=${{ secrets.TMTA_USERNAME }}' >> ${{ env.API_ENV_FILE }} &&
+            echo 'SUPERADMIN_USERNAME=${{ secrets.SUPERADMIN_USERNAME }}' >> ${{ env.API_ENV_FILE }} &&
+            echo 'SUPERADMIN_EMAIL=${{ vars.SUPERADMIN_EMAIL }}' >> ${{ env.API_ENV_FILE }} &&
+            echo 'SUPERADMIN_PASSWORD='\''${{ secrets.SUPERADMIN_PASSWORD }}'\''' >> ${{ env.API_ENV_FILE }} &&
+            echo 'DEMO_USERNAME=${{ secrets.DEMO_USERNAME }}' >> ${{ env.API_ENV_FILE }} &&
+            echo 'DEMO_EMAIL=${{ vars.DEMO_EMAIL }}' >> ${{ env.API_ENV_FILE }} &&
+            echo 'DEMO_PASSWORD='\''${{ secrets.DEMO_PASSWORD }}'\''' >> ${{ env.API_ENV_FILE }} &&
 
             chmod 600 ${{ env.API_ENV_FILE }}
           EOF

--- a/api/migrations/0005_create_superadmin_and_demo_users.py
+++ b/api/migrations/0005_create_superadmin_and_demo_users.py
@@ -1,0 +1,80 @@
+# api/migrations/0005_create_superadmin_and_demo_users
+import os
+from django.db import migrations
+from django.core.management.base import CommandError
+from django.contrib.auth.hashers import make_password
+
+
+def create_superadmin_user(apps, schema_editor):
+    User = apps.get_model("api", "User")
+    username = os.getenv("SUPERADMIN_USERNAME")
+    password = os.getenv("SUPERADMIN_PASSWORD")
+    if not username:
+        raise CommandError(
+            "SUPERADMIN_USERNAME must be set in environment variables before running migrations."
+        )
+    if not password:
+        raise CommandError(
+            "SUPERADMIN_PASSWORD must be set in environment variables before running migrations."
+        )
+    email = os.getenv("SUPERADMIN_EMAIL", "").strip() or f"{username}@example.com"
+    user, created = User.objects.get_or_create(
+        username=username,
+        defaults={
+            "email": email,
+            "is_active": True,
+            "is_staff": True,
+            "is_superuser": True,
+            "is_system": False,
+        },
+    )
+    user.password = make_password(password)
+    user.email = email
+    user.is_staff = True
+    user.is_superuser = True
+    user.is_active = True
+    user.save(update_fields=["password", "email", "is_staff", "is_superuser", "is_active"])
+
+
+def create_demo_user(apps, schema_editor):
+    User = apps.get_model("api", "User")
+    username = os.getenv("DEMO_USERNAME")
+    password = os.getenv("DEMO_PASSWORD")
+    if not username:
+        raise CommandError(
+            "DEMO_USERNAME must be set in environment variables before running migrations."
+        )
+    if not password:
+        raise CommandError(
+            "DEMO_PASSWORD must be set in environment variables before running migrations."
+        )
+    email = os.getenv("DEMO_EMAIL", "").strip() or f"{username}@example.com"
+    user, created = User.objects.get_or_create(
+        username=username,
+        defaults={
+            "email": email,
+            "is_active": True,
+            "is_staff": False,
+            "is_superuser": False,
+            "is_system": False,
+        },
+    )
+    user.password = make_password(password)
+    user.email = email
+    user.is_active = True
+    user.save(update_fields=["password", "email", "is_active"])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api", "0004_seed_missing_cause_codes"),
+    ]
+
+    operations = [
+        migrations.RunPython(create_superadmin_user, noop),
+        migrations.RunPython(create_demo_user, noop),
+    ]

--- a/bruno/Track/environments/test demo.bru
+++ b/bruno/Track/environments/test demo.bru
@@ -1,0 +1,7 @@
+vars {
+  BASE_URL: https://hear-api.themusictree.org/v1.0.3-dev-add-users/
+  USERNAME: demo
+}
+vars:secret [
+  PASSWORD
+]


### PR DESCRIPTION
## Description

Add a data migration that creates **superadmin** and **demo** users from environment variables (GitHub vars and secrets). The migration fails if required env vars are not set. Deploy workflow is updated to pass and validate these vars/secrets.

## Related Issue

<!-- Link to related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [x] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [ ] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

### Migration `0005_create_superadmin_and_demo_users`
- **Superadmin user**: created/updated when `SUPERADMIN_USERNAME` and `SUPERADMIN_PASSWORD` are set; optional `SUPERADMIN_EMAIL` (default `{username}@example.com`). User has `is_staff=True`, `is_superuser=True`.
- **Demo user**: created/updated when `DEMO_USERNAME` and `DEMO_PASSWORD` are set; optional `DEMO_EMAIL` (default `{username}@example.com`). Normal active user.
- Migration raises `CommandError` and fails if any of `SUPERADMIN_USERNAME`, `SUPERADMIN_PASSWORD`, `DEMO_USERNAME`, or `DEMO_PASSWORD` are missing.

### Deploy workflow `deploy-env-and-docker-compose.yml`
- **Check step**: Added `SUPERADMIN_USERNAME`, `SUPERADMIN_EMAIL`, `SUPERADMIN_PASSWORD`, `DEMO_USERNAME`, `DEMO_EMAIL`, `DEMO_PASSWORD` to the `env` block and to `check-workflow-env.sh` so the workflow fails early if they are not configured.
- **API env file**: Write the same vars/secrets into the API env file so the container has them when migrations run.

### GitHub configuration required
- **Secrets**: `SUPERADMIN_USERNAME`, `SUPERADMIN_PASSWORD`, `DEMO_USERNAME`, `DEMO_PASSWORD`
- **Variables**: `SUPERADMIN_EMAIL`, `DEMO_EMAIL` (optional; migration uses defaults if unset)

## Testing

- [x] All existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed (if applicable)

**Test commands:**
```bash
pytest
```

## Checklist

### Code Quality
- [x] Code follows project style guidelines ([code-style.md](code-style.md))
- [x] Code follows Django best practices
- [x] Type hints added where appropriate
- [x] No debug statements or commented-out code
- [x] One class per file (if applicable)
- [x] Field name constants used (if applicable)

### Tests
- [x] All tests pass: `pytest`
- [ ] New features have corresponding tests
- [ ] Bug fixes include regression tests
- [x] Tests follow naming convention: `test_{scenario}_then_{expected_result}`
- [x] Each test focuses on a single scenario

### Documentation
- [x] Docstrings updated (only when needed)
- [ ] README updated (if applicable)
- [ ] CHANGELOG.md updated in `[Unreleased]` section
- [x] Type hints added/updated

### Git Hygiene
- [x] Commit messages follow convention: `<type>(<scope>): <summary>`
- [ ] Branch is up to date with target branch
- [x] Branch follows naming convention (`feature/`, `chore/`, etc.)
- [x] No accidental commits (large files, secrets, personal configs)

## Breaking Changes

- [ ] This PR includes breaking changes
- [ ] Breaking changes are documented in the description above
- [ ] Migration path provided (if applicable)

**Breaking Changes:**
N/A

## Screenshots (if applicable)

N/A

## Additional Notes

- Deploy will fail until the new secrets and (optionally) variables are set in the GitHub environment used by the workflow.

## Reviewer Notes

- Confirm migration fails clearly when required env vars are missing.
- Confirm workflow check step and API env file wiring for superadmin/demo vars and secrets.
