### PR TITLE
chore: update CHANGELOG.md for version 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+## [v2.0.2] - 2026-02-21
+
 ### Fixed
 
 - **Spotify auth**: When Spotify returns `invalid_client` (e.g. wrong/missing app credentials), API now returns 500 with a generic "Sign-in is temporarily misconfigured" message instead of 401, since the failure is server configuration, not the user


### PR DESCRIPTION
- Added entry for version 2.0.2, documenting the fix for Spotify authentication error handling, which now returns a 500 error with a user-friendly message for invalid client credentials.