### PR TITLE
feature: handle spotify allow list

### DIFF
--- a/.github/workflows/deploy-env-and-docker-compose.yml
+++ b/.github/workflows/deploy-env-and-docker-compose.yml
@@ -234,11 +234,13 @@ jobs:
           API_HOST="${{ steps.set_api_host.outputs.api_host }}"
           IP_LIST="${{ steps.resolve_api_ips.outputs.ip_list }}"
           APP_PORT="${{ vars.APP_PORT }}"
-          CSRF_ORIGINS="https://${{ vars.DOMAIN_NAME }},https://${API_HOST}"
+          DOMAIN_NAME="${{ vars.DOMAIN_NAME }}"
+          CSRF_ORIGINS="https://${DOMAIN_NAME},https://www.${DOMAIN_NAME},https://${API_HOST}"
+          BASE_ALLOWED="${API_HOST},www.${API_HOST},${DOMAIN_NAME},www.${DOMAIN_NAME}"
           if [ -n "${IP_LIST}" ]; then
-            ALLOWED_HOSTS="${API_HOST},www.${API_HOST},${IP_LIST},localhost,localhost:${APP_PORT}"
+            ALLOWED_HOSTS="${BASE_ALLOWED},${IP_LIST},localhost,localhost:${APP_PORT}"
           else
-            ALLOWED_HOSTS="${API_HOST},www.${API_HOST},localhost,localhost:${APP_PORT}"
+            ALLOWED_HOSTS="${BASE_ALLOWED},localhost,localhost:${APP_PORT}"
           fi
           echo "csrf_origins=${CSRF_ORIGINS}" >> $GITHUB_OUTPUT
           echo "allowed_hosts=${ALLOWED_HOSTS}" >> $GITHUB_OUTPUT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,8 +62,18 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 ### Fixed
 
 - **Deploy**: Requests to the bare domain (e.g. `themusictree.org`) and `www` no longer trigger `DisallowedHost`. Deploy workflow now adds the domain and `www.${DOMAIN_NAME}` to `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS`.
+- **Request logging**: Fixed "Error reading request body: You cannot access body after reading from request's data stream" on multipart requests (e.g. track upload to `uploaded/`). RequestLoggingMiddleware no longer reads `request.body` for `multipart/form-data` and logs a placeholder instead. Includes unit test.
 
 - **Spotify OAuth**: Fixed backend always returning the same Spotify user regardless of which account completed login. Spotipy’s token cache was used by default, so the first user’s token was returned for every subsequent code exchange. The code exchange now uses `check_cache=False` so each login uses the provided authorization code.
+
+### Removed
+
+- **Admin**: SpotifyUser is no longer registered in Django admin (model was removed in v2.0.0 unified account).
+
+### Changed
+
+- **Dev env example**: `APP_NAME` default set to `htmt-api` (was `htmt_api`).
+- **Scripts**: `run-db-and-afp-containers.sh` loads `env/.env` when present before running containers; `utils.sh` env loader trims keys and skips lines starting with `#`; `purge-django-data` cleanup (removed unused variable and redundant debug logs).
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ### Fixed
 
+- **Deploy**: Requests to the bare domain (e.g. `themusictree.org`) and `www` no longer trigger `DisallowedHost`. Deploy workflow now adds the domain and `www.${DOMAIN_NAME}` to `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS`.
+
 - **Spotify OAuth**: Fixed backend always returning the same Spotify user regardless of which account completed login. Spotipy’s token cache was used by default, so the first user’s token was returned for every subsequent code exchange. The code exchange now uses `check_cache=False` so each login uses the provided authorization code.
 
 ### Improved

--- a/api/admin.py
+++ b/api/admin.py
@@ -21,13 +21,11 @@ from .model.uploaded_track.file.TrackFile import TrackFile
 from .model.uploaded_track.UploadedTrack import UploadedTrack
 from .model.user.admin.UserAdmin import UserAdmin
 from .model.user.User import User
-from .model.user.spotify.SpotifyUser import SpotifyUser
 from .model.spotify_resource.children.track.SpotifyLibTrack import SpotifyLibTrack
 from .model.spotify_resource.children.artist.SpotifyArtist import SpotifyArtist
 
 
 admin.site.register(User, UserAdmin)
-admin.site.register(SpotifyUser)
 admin.site.register(UploadedTrack)
 admin.site.register(TrackFile)
 admin.site.register(FingerprintMissingCause)

--- a/api/middleware/RequestLoggingMiddleware.py
+++ b/api/middleware/RequestLoggingMiddleware.py
@@ -32,16 +32,18 @@ class RequestLoggingMiddleware:
         self.requestDebugLogger.info(logMessage)
         self.requestDebugLogger.info(_generate_log_about_headers(request))
 
-        # Log request body for non-GET requests
+        # Log request body for non-GET requests (skip multipart: stream is consumed by POST/FILES parsing)
         if request.method != 'GET':
             try:
-                # Try to get the body from the request attribute first (set by other middleware)
-                body = getattr(request, '_body', None)
-                if body is None:
-                    # If not set, try to read the body directly
-                    body = request.body
-                    # Store the body in a request attribute for other middleware
-                    request._body = body
+                content_type = (request.content_type or "").lower()
+                if content_type.startswith("multipart/"):
+                    self.requestDebugLogger.info(f"[{request_id}] Request Body: <multipart form data>")
+                    body = None
+                else:
+                    body = getattr(request, '_body', None)
+                    if body is None:
+                        body = request.body
+                        request._body = body
 
                 if body:
                     try:

--- a/api/test/tests/unit/middleware/test_request_logging_middleware.py
+++ b/api/test/tests/unit/middleware/test_request_logging_middleware.py
@@ -1,0 +1,29 @@
+from unittest.mock import Mock
+
+from django.http import HttpRequest
+
+from api.middleware.RequestLoggingMiddleware import RequestLoggingMiddleware
+
+
+class TestRequestLoggingMiddleware:
+
+    def test_multipart_post_then_passes_through_without_reading_body(self):
+        """Multipart request must not read request.body (stream already consumed by POST/FILES)."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+
+        def mock_get_response(req):
+            return mock_response
+
+        middleware = RequestLoggingMiddleware(get_response=mock_get_response)
+
+        request = HttpRequest()
+        request.method = "POST"
+        request.path = "/me/library/uploaded/"
+        request.META = {"REMOTE_ADDR": "127.0.0.1"}
+        request.content_type = "multipart/form-data; boundary=----boundary"
+        request.headers = {}
+
+        response = middleware.__call__(request)
+
+        assert response == mock_response

--- a/env/dev/.env.dev.example
+++ b/env/dev/.env.dev.example
@@ -1,6 +1,6 @@
 ENV=DEV
 
-APP_NAME=htmt_api
+APP_NAME=htmt-api
 APP_TITLE="TheMusicTreeAPI"
 APP_VERSION=1.0.4
 API_DIR_NAME=api

--- a/scripts/purge-django-data-USE-WITH-CAUTION.sh
+++ b/scripts/purge-django-data-USE-WITH-CAUTION.sh
@@ -96,13 +96,10 @@ empty_db() {
 		force_close_db_connections_if_exist $db_name
 
 		log_with_script_prefixe "Checking if database $db_name exists..."
-		sql="SELECT 1 FROM pg_database WHERE datname='${!db_name}'"
 		output=$(timeout ${DB_TIMEOUT_SECONDS}s psql -h $DB_HOST -p $DB_PORT -U $DB_SUPERUSER_NAME -tAc \
 		"SELECT 1 FROM pg_database WHERE datname='${db_name}'" 2>&1)
 		exit_code=$?
 		handle_db_timeout $exit_code
-		log_with_script_prefixe "${!db_name}"
-		log_with_script_prefixe "${db_name}"
 		log_with_script_prefixe "$output"
 		if [ "$output" = "1" ]; then
 			log_with_script_prefixe "Database $db_name exists. Dropping database..."

--- a/scripts/run-db-and-afp-containers.sh
+++ b/scripts/run-db-and-afp-containers.sh
@@ -42,6 +42,13 @@ main() {
     APP_ENV_FILE="${PROJECT_DIR}env/.env"
     source "${SCRIPTS_DIR}utils.sh"
 
+    if [ -f "$APP_ENV_FILE" ]; then
+        set -a
+        . "$APP_ENV_FILE"
+        set +a
+        log_with_script_prefixe "Loaded env from $APP_ENV_FILE"
+    fi
+
     log_with_script_prefixe "Running the database and audio fingerprinter containers..."
 
     check_script_vars_are_set

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -104,8 +104,9 @@ load_app_env_file_if_exists() {
     else
         log_with_utils_prefixe "Loading environment variables from ${ENV_FILE} ..."
         while IFS='=' read -r key value; do
-            # Skip comments and empty lines
-            if [ -z "$key" ]; then continue; fi
+            key="${key#"${key%%[![:space:]]*}"}"
+            key="${key%"${key##*[![:space:]]}"}"
+            if [ -z "$key" ] || [ "${key#\#}" != "$key" ]; then continue; fi
             export "$key=$value"
         done < "$ENV_FILE"
     fi


### PR DESCRIPTION
## Description

Fixes and small improvements across deploy, request logging, admin, dev env, and scripts:

- **Deploy**: Bare domain and `www` are now in `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS`, so requests to e.g. `themusictree.org` and `www.themusictree.org` no longer trigger `DisallowedHost`.
- **Request logging**: Stops reading `request.body` for `multipart/form-data` so multipart requests (e.g. track upload to `uploaded/`) no longer hit "Error reading request body: You cannot access body after reading from request's data stream". Logs a placeholder for multipart instead.
- **Admin**: Unregister `SpotifyUser` from Django admin (model was removed in v2.0.0 unified account).
- **Dev env example**: `APP_NAME` default set to `htmt-api` (was `htmt_api`).
- **Scripts**: `run-db-and-afp-containers.sh` loads `env/.env` when present; `utils.sh` env loader trims keys and skips `#` lines; `purge-django-data` cleanup (unused variable and redundant debug logs removed).

## Related Issue

N/A (misc fixes and improvements).

## Type of Change

- [x] Bug fix (non-breaking)
- [x] Chore / maintenance
- [ ] New feature
- [ ] Breaking change

## Target Branch

`develop`

## Changes Made

- **`.github/workflows/deploy-env-and-docker-compose.yml`**: Add `DOMAIN_NAME` and `www.${DOMAIN_NAME}` to `CSRF_ORIGINS` and `ALLOWED_HOSTS`.
- **`api/middleware/RequestLoggingMiddleware.py`**: For `multipart/form-data`, skip reading `request.body` and log `<multipart form data>`.
- **`api/test/tests/unit/middleware/test_request_logging_middleware.py`**: New unit test that multipart POST passes through without reading body.
- **`api/admin.py`**: Remove `SpotifyUser` from admin registration and its import.
- **`env/dev/.env.dev.example`**: `APP_NAME=htmt-api`.
- **`scripts/run-db-and-afp-containers.sh`**: Source `env/.env` if present before running containers.
- **`scripts/utils.sh`**: In env loader, trim key and skip lines where key is empty or starts with `#`.
- **`scripts/purge-django-data-USE-WITH-CAUTION.sh`**: Remove unused `sql` variable and redundant `log_with_script_prefixe` calls.
- **`CHANGELOG.md`**: Unreleased entries for all of the above.

## Testing

- `pytest api/test/tests/unit/middleware/test_request_logging_middleware.py -v`
- Run full test suite: `pytest`

## Checklist

- [x] Code follows project style and conventions
- [x] CHANGELOG.md updated under [Unreleased]
- [x] No debug or commented-out code
- [x] Tests added/updated where relevant (RequestLoggingMiddleware unit test)

## Breaking Changes

None.

## Additional Notes

- Request logging fix addresses the error seen when uploading tracks to `me/library/uploaded/` (multipart body already consumed by earlier middleware).
