### PR TITLE
chore: update CHANGELOG.md for version 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+## [v2.0.1] - 2026-02-22
+
 ### Fixed
 
 - **Deploy**: Requests to the bare domain (e.g. `themusictree.org`) and `www` no longer trigger `DisallowedHost`. Deploy workflow now adds the domain and `www.${DOMAIN_NAME}` to `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS`.


### PR DESCRIPTION
- Added entry for version 2.0.1, documenting the fix for requests to the bare domain and `www` that previously triggered `DisallowedHost`. The deployment workflow now includes these domains in `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS`.