### PR TITLE
chore: update audiometa-python dependency to version 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+### Changed
+
+- **Dependencies**: Bumped `audiometa-python` from 1.0.0 to 1.1.0.
+
 ## [v2.1.0] - 2026-02-23
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 asgiref==3.8.1
-audiometa-python==1.0.0
+audiometa-python==1.1.0
 autoflake==2.3.1
 bcrypt==3.1.7
 blinker==1.4


### PR DESCRIPTION
# PR Description

## Description

Bump `audiometa-python` from 1.0.0 to 1.1.0.

## Related Issue

_None._

## Type of Change

- [x] Chore (dependency update)

## Target Branch

`develop`

## Changes Made

- **requirements.txt**: `audiometa-python==1.0.0` → `audiometa-python==1.1.0`

## Testing

- Existing tests should pass; no API or behavior change.
- Run: `pytest`

## Checklist

- [x] Dependency version pinned (exact version in requirements.txt)
- [x] CHANGELOG.md updated under `[Unreleased]`
- [x] Branch up to date with `develop`

## Breaking Changes

None.

## Additional Notes

_None._
