### PR TITLE
refactor: update get_full_metadata function parameter for raw binary …

### DIFF
--- a/api/utils/audio_file_metadata/audiometa_adapter.py
+++ b/api/utils/audio_file_metadata/audiometa_adapter.py
@@ -142,11 +142,11 @@ def get_duration_in_sec(file: FILE_TYPE) -> float:
         raise FileCorruptedError(str(e)) from e
 
 
-def get_full_metadata(file: FILE_TYPE, include_cover: bool) -> dict:
+def get_full_metadata(file: FILE_TYPE, include_raw_binary_data: bool) -> dict:
     """Get full metadata."""
     file_path = _get_file_path_util(file)
     try:
-        return audiometa.get_full_metadata(file=file_path, include_cover=include_cover)
+        return audiometa.get_full_metadata(file=file_path, include_raw_binary_data=include_raw_binary_data)
     except AudiometaFileCorruptedError as e:
         raise FileCorruptedError(str(e)) from e
 

--- a/api/view/AudioMetadataView.py
+++ b/api/view/AudioMetadataView.py
@@ -26,5 +26,5 @@ class AudioMetadataView(APIView):
         serializer.is_valid(raise_exception=True)
         file: audiometa_adapter.FILE_TYPE = serializer.validated_data.get(
             Fields.FILE)   # pyright: ignore[reportAssignmentType]
-        full_metadata = audiometa_adapter.get_full_metadata(file, include_cover=False)
+        full_metadata = audiometa_adapter.get_full_metadata(file, include_raw_binary_data=False)
         return Response(data=full_metadata, status=status.HTTP_200_OK)


### PR DESCRIPTION
# PR Description

## Description

Align the audio metadata adapter and view with the underlying `audiometa` library by renaming the `get_full_metadata` parameter from `include_cover` to `include_raw_binary_data`. The library controls whether raw binary data (e.g. cover art) is included in the response; the new name reflects that behavior.

## Related Issue

N/A

## Type of Change

- [x] Refactor (non-breaking API alignment)

## Target Branch

`develop`

## Changes Made

- **`api/utils/audio_file_metadata/audiometa_adapter.py`**: Renamed `get_full_metadata(..., include_cover=...)` to `get_full_metadata(..., include_raw_binary_data=...)` and pass the parameter through to `audiometa.get_full_metadata`.
- **`api/view/AudioMetadataView.py`**: Updated call to use `include_raw_binary_data=False` instead of `include_cover=False`.

## Testing

- Existing tests for audio metadata / full metadata should cover behavior (no functional change; call site still passes `False`).

## Checklist

- [x] Code follows project style and one-class-per-file
- [x] No new dependencies
- [x] CHANGELOG updated (if applicable)

## Breaking Changes

None. Internal parameter rename only; public API (response shape, endpoint contract) unchanged.
