### PR TITLE
fix(ci): run actionlint with config in branch protection

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -50,5 +50,18 @@ jobs:
             fi
           fi
 
+  actionlint:
+    name: Actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install actionlint
+        run: |
+          VERSION="1.7.11"
+          curl -sSL "https://github.com/rhysd/actionlint/releases/download/v${VERSION}/actionlint_${VERSION}_linux_amd64.tar.gz" | tar xz -C /tmp
+
+      - name: Lint workflows
+        run: /tmp/actionlint -config-file .github/actionlint.yaml
 
 


### PR DESCRIPTION
## Description

Add an Actionlint job to the Branch Protection Check workflow so CI runs actionlint with `.github/actionlint.yaml`. Without the config, actionlint reports false positives for jobs that call reusable workflows (e.g. "Unexpected value 'uses'/'with'/'secrets'" in `publish-staging.yml`). The config file already contains ignore rules for these; CI must invoke actionlint with `-config-file` for those rules to apply.

## Related Issue

N/A

## Type of Change

- [x] CI / workflow change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Other

## Target Branch

`develop`

## Changes Made

- **`.github/workflows/branch-protection.yml`**:
  - New job `actionlint`: runs on every PR to `main` and `develop`
  - Checkout, install actionlint v1.7.11 (Linux amd64), run `actionlint -config-file .github/actionlint.yaml`

## Testing

- Open a PR targeting `develop`; the "Actionlint" job should run and pass.
- Locally: `actionlint -config-file .github/actionlint.yaml` exits 0 with no output.

## Checklist

- [ ] Branch is up to date with `develop`
- [ ] Commit messages follow convention
- [ ] No unrelated changes

## Breaking Changes

None

## Additional Notes

- Existing `.github/actionlint.yaml` ignore rules (e.g. for job-level `uses`/`with`/`secrets` on reusable workflow calls) are unchanged; this PR only ensures CI uses that config.
