### PR TITLE
fix(audio): standardize download headers and filename handling

### DIFF
--- a/.cursor/rules/changelog-entry-placement.mdc
+++ b/.cursor/rules/changelog-entry-placement.mdc
@@ -1,0 +1,19 @@
+---
+description: Ensure changelog entries are added in the real section, not examples
+alwaysApply: true
+---
+# Changelog Entry Placement and De-duplication
+
+When adding or updating entries in `CHANGELOG.md`:
+
+1. Add entries only under the real `## [Unreleased]` section (or the active release section when explicitly requested).
+2. Never add entries inside documentation/example fenced code blocks (e.g. inside the ` ```markdown ` example near the top).
+3. Before writing a new entry, scan the target section and avoid duplicates or near-duplicates.
+4. If a matching entry already exists, update/merge the existing bullet instead of adding another one.
+5. Keep category placement correct (`Added`, `Changed`, `Fixed`, `Documentation`, `CI`, etc.).
+
+## Quick validation checklist
+
+- The new bullet is outside any fenced code block.
+- The bullet is under the intended real section heading.
+- No equivalent bullet already exists in `Unreleased` or the target release section.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,6 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 ```markdown
 ## [Unreleased]
 
-### Fixed
-
-- **Metadata session download headers**: File download responses now set standards-compliant `Content-Disposition` with both `filename` (ASCII fallback) and `filename*` (RFC5987 UTF-8), expose `Content-Disposition` to browser JS via `Access-Control-Expose-Headers`, and return a real MIME type (with fallback to `application/octet-stream`) instead of a generic `file` content type.
-
 ### Added
 
 - **Track API**: Added batch upload endpoint for multiple tracks
@@ -62,6 +58,10 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 **Note:** During releases, maintainers will move entries from `[Unreleased]` to a versioned section (e.g., `## [0.2.8] - 2025-01-XX`).
 
 ## [Unreleased]
+
+### Fixed
+
+- **Metadata session download headers**: File download responses now set standards-compliant `Content-Disposition` with both `filename` (ASCII fallback) and `filename*` (RFC5987 UTF-8), expose `Content-Disposition` to browser JS via `Access-Control-Expose-Headers`, and return a real MIME type (with fallback to `application/octet-stream`) instead of a generic `file` content type.
 
 ### CI
 

--- a/api/test/tests/integration/audio_metadata/test_metadata_session.py
+++ b/api/test/tests/integration/audio_metadata/test_metadata_session.py
@@ -53,7 +53,10 @@ class TestMetadataSessionUpload(AudioMetadataTestCase):
         assert "attachment" in content_disposition
         assert "filename=" in content_disposition
         assert "filename*=" in content_disposition
-        assert download_response.get("Access-Control-Expose-Headers") == "Content-Disposition"
+        expose_headers = download_response.get("Access-Control-Expose-Headers")
+        assert expose_headers is not None
+        exposed_headers = [header.strip().lower() for header in expose_headers.split(",")]
+        assert "content-disposition" in exposed_headers
         assert download_response.get("Content-Type") == "audio/mpeg"
 
     def test_download_without_token_then_400(self):

--- a/api/test/tests/unit/view/file_response/test_app_file_response.py
+++ b/api/test/tests/unit/view/file_response/test_app_file_response.py
@@ -11,6 +11,12 @@ class TestAppFileResponse:
         assert "music/" not in content_disposition
         assert "../" not in content_disposition
 
+    def test_filename_with_windows_path_then_uses_basename_in_content_disposition(self):
+        content_disposition = AppFileResponse._build_content_disposition("C:\\music\\my track.mp3")
+        assert 'filename="my track.mp3"' in content_disposition
+        assert "music" not in content_disposition
+        assert "C:" not in content_disposition
+
     def test_filename_with_control_chars_then_removes_control_chars_in_content_disposition(self):
         content_disposition = AppFileResponse._build_content_disposition("my\r\ntrack.mp3")
         assert "\r" not in content_disposition
@@ -27,14 +33,22 @@ class TestAppFileResponse:
         assert 'filename="download"' in content_disposition
         assert "filename*=UTF-8''download" in content_disposition
 
+    def test_filename_with_non_ascii_only_name_then_uses_download_fallback(self):
+        content_disposition = AppFileResponse._build_content_disposition("🎵.mp3")
+        assert 'filename="download.mp3"' in content_disposition
+        assert "filename*=UTF-8''%F0%9F%8E%B5.mp3" in content_disposition
+
     def test_from_file_with_known_extension_then_sets_detected_content_type(self):
         with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp_file:
             tmp_file.write(b"content")
             file_path = tmp_file.name
+        response = None
         try:
             response = AppFileResponse.from_file(file_path=file_path, filename="track.mp3")
             assert response.get("Content-Type") == "audio/mpeg"
         finally:
+            if response is not None:
+                response.close()
             if os.path.exists(file_path):
                 os.unlink(file_path)
 
@@ -42,9 +56,12 @@ class TestAppFileResponse:
         with tempfile.NamedTemporaryFile(suffix=".unknownext", delete=False) as tmp_file:
             tmp_file.write(b"content")
             file_path = tmp_file.name
+        response = None
         try:
             response = AppFileResponse.from_file(file_path=file_path, filename="track.unknownext")
             assert response.get("Content-Type") == "application/octet-stream"
         finally:
+            if response is not None:
+                response.close()
             if os.path.exists(file_path):
                 os.unlink(file_path)

--- a/api/test/tests/unit/view/file_response/test_app_file_response.py
+++ b/api/test/tests/unit/view/file_response/test_app_file_response.py
@@ -1,0 +1,50 @@
+import os
+import tempfile
+
+from api.view.file_response.AppFileResponse import AppFileResponse
+
+
+class TestAppFileResponse:
+    def test_filename_with_path_then_uses_basename_in_content_disposition(self):
+        content_disposition = AppFileResponse._build_content_disposition("../../music/my track.mp3")
+        assert 'filename="my track.mp3"' in content_disposition
+        assert "music/" not in content_disposition
+        assert "../" not in content_disposition
+
+    def test_filename_with_control_chars_then_removes_control_chars_in_content_disposition(self):
+        content_disposition = AppFileResponse._build_content_disposition("my\r\ntrack.mp3")
+        assert "\r" not in content_disposition
+        assert "\n" not in content_disposition
+        assert 'filename="mytrack.mp3"' in content_disposition
+
+    def test_filename_with_non_ascii_then_sets_ascii_fallback_and_utf8_filename(self):
+        content_disposition = AppFileResponse._build_content_disposition("café 🎵.mp3")
+        assert 'filename="caf .mp3"' in content_disposition
+        assert "filename*=UTF-8''caf%C3%A9%20%F0%9F%8E%B5.mp3" in content_disposition
+
+    def test_empty_filename_then_uses_download_for_filename_and_filename_star(self):
+        content_disposition = AppFileResponse._build_content_disposition("")
+        assert 'filename="download"' in content_disposition
+        assert "filename*=UTF-8''download" in content_disposition
+
+    def test_from_file_with_known_extension_then_sets_detected_content_type(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp3", delete=False) as tmp_file:
+            tmp_file.write(b"content")
+            file_path = tmp_file.name
+        try:
+            response = AppFileResponse.from_file(file_path=file_path, filename="track.mp3")
+            assert response.get("Content-Type") == "audio/mpeg"
+        finally:
+            if os.path.exists(file_path):
+                os.unlink(file_path)
+
+    def test_from_file_with_unknown_extension_then_sets_octet_stream_content_type(self):
+        with tempfile.NamedTemporaryFile(suffix=".unknownext", delete=False) as tmp_file:
+            tmp_file.write(b"content")
+            file_path = tmp_file.name
+        try:
+            response = AppFileResponse.from_file(file_path=file_path, filename="track.unknownext")
+            assert response.get("Content-Type") == "application/octet-stream"
+        finally:
+            if os.path.exists(file_path):
+                os.unlink(file_path)

--- a/api/view/AudioMetadataSessionDownloadView.py
+++ b/api/view/AudioMetadataSessionDownloadView.py
@@ -40,7 +40,10 @@ class AudioMetadataSessionDownloadView(APIView):
             "Download the file for the given session token with optional metadata written in. "
             "Send session_token in X-Session-Token header or in JSON body. Metadata fields are optional; "
             "only provided fields are written. Session is valid 15 minutes; you can call this multiple times "
-            "with different metadata. Returns 404/410 if token is missing or expired."
+            "with different metadata. Returns 404/410 if token is missing or expired. "
+            "On success, the response sets Content-Type from the file, Content-Disposition with attachment "
+            "and both filename (ASCII fallback) and filename* (RFC 5987 UTF-8), and "
+            "Access-Control-Expose-Headers: Content-Disposition for cross-origin clients."
         ),
     )
     def post(self, request):

--- a/api/view/file_response/AppFileResponse.py
+++ b/api/view/file_response/AppFileResponse.py
@@ -42,14 +42,16 @@ class AppFileResponse:
             return "download"
         _, extension = os.path.splitext(filename)
         fallback = filename.encode("ascii", "ignore").decode("ascii")
-        fallback = fallback.replace('"', "")
-        if fallback:
+        fallback = fallback.replace('"', "").replace("\\", "").strip()
+        fallback_stem = fallback[: -len(extension)] if extension and fallback.endswith(extension) else fallback
+        if fallback and fallback_stem.strip():
             return fallback
         return f"download{extension}" if extension else "download"
 
     @staticmethod
     def _build_effective_filename(filename: str) -> str:
-        basename = os.path.basename(filename or "")
+        normalized = (filename or "").replace("\\", "/")
+        basename = os.path.basename(normalized)
         sanitized_chars = []
         for char in basename:
             char_code = ord(char)

--- a/api/view/file_response/AppFileResponse.py
+++ b/api/view/file_response/AppFileResponse.py
@@ -28,8 +28,9 @@ class AppFileResponse:
 
     @staticmethod
     def _build_content_disposition(filename: str) -> str:
-        fallback_filename = AppFileResponse._build_ascii_fallback_filename(filename)
-        encoded_filename = quote(filename, safe="")
+        effective_filename = AppFileResponse._build_effective_filename(filename)
+        fallback_filename = AppFileResponse._build_ascii_fallback_filename(effective_filename)
+        encoded_filename = quote(effective_filename, safe="")
         return (
             f'attachment; filename="{fallback_filename}"; '
             f"filename*=UTF-8''{encoded_filename}"
@@ -45,3 +46,15 @@ class AppFileResponse:
         if fallback:
             return fallback
         return f"download{extension}" if extension else "download"
+
+    @staticmethod
+    def _build_effective_filename(filename: str) -> str:
+        basename = os.path.basename(filename or "")
+        sanitized_chars = []
+        for char in basename:
+            char_code = ord(char)
+            if char_code < 32 or char_code == 127:
+                continue
+            sanitized_chars.append(char)
+        sanitized_filename = "".join(sanitized_chars).strip()
+        return sanitized_filename or "download"

--- a/docs/api/audio_metadata_session.md
+++ b/docs/api/audio_metadata_session.md
@@ -84,7 +84,10 @@ Body example:
 
 **Response**
 
-- **200 OK**: Body is the audio file (binary). Headers include `Content-Disposition: attachment; filename="<original_filename>"`.
+- **200 OK**: Body is the audio file (binary). Headers include:
+  - `Content-Type`: MIME type inferred from the session file (typically `audio/mpeg`, `audio/flac`, or `audio/wav`; unknown extensions use `application/octet-stream`).
+  - `Content-Disposition: attachment; filename="<ascii-fallback>"; filename*=UTF-8''<url-encoded-utf8-filename>` (RFC 5987 for non-ASCII names).
+  - `Access-Control-Expose-Headers: Content-Disposition` (so browser JavaScript can read `Content-Disposition` on cross-origin responses).
 - **400 Bad Request**: Missing session token.
 - **410 Gone**: Session not found or expired. Client should create a new session (upload again).
 

--- a/docs/frontend/one_time_metadata_update.md
+++ b/docs/frontend/one_time_metadata_update.md
@@ -58,7 +58,7 @@ If your API returns camelCase (e.g. `sessionToken`, `sessionExpiresInSeconds`), 
     - Or in JSON body: `session_token: "<sessionToken>"`
   - **Metadata (optional)** — JSON body with any of: `title`, `artists_names`, `album_name`, `album_artists_names`, `genres_names` (list of strings), `rating`, `language`. Only provided fields are written; omit a field to leave it unchanged. To get the file as-is, send an empty object `{}` but still send the token (e.g. in the header).
 - **Response**:
-  - `200 OK`: Body is the **binary audio file**. Response header `Content-Disposition: attachment; filename="..."` gives the suggested filename.
+  - `200 OK`: Body is the **binary audio file**. Headers include `Content-Type` (MIME type for the file), `Content-Disposition` with both `filename="..."` (ASCII fallback) and `filename*=UTF-8''...` (preferred UTF-8 name), and `Access-Control-Expose-Headers: Content-Disposition` so frontend JS can read that header cross-origin.
   - `400 Bad Request`: Missing session token.
   - `410 Gone`: Session expired or invalid. Prompt the user to upload again.
 
@@ -89,7 +89,10 @@ if (!response.ok) {
 }
 
 const blob = await response.blob();
-const filename = response.headers.get("Content-Disposition")?.match(/filename="(.+)"/)?.[1] ?? "download.mp3";
+const contentDisposition = response.headers.get("Content-Disposition") ?? "";
+const filenameStar = contentDisposition.match(/filename\*=UTF-8''([^;]+)/i)?.[1];
+const filenameBasic = contentDisposition.match(/filename="([^"]+)"/i)?.[1];
+const filename = filenameStar ? decodeURIComponent(filenameStar) : (filenameBasic ?? "download");
 // Trigger download: e.g. create object URL and <a download>
 const url = URL.createObjectURL(blob);
 const a = document.createElement("a");


### PR DESCRIPTION
- [x] Understand review feedback
- [x] Fix `_build_effective_filename`: normalize `\\` to `/` before `os.path.basename` (cross-platform path stripping)
- [x] Fix `_build_ascii_fallback_filename`: strip whitespace, remove backslashes, treat empty-stem fallback as invalid (e.g., `🎵.mp3` → `download.mp3`)
- [x] Fix test file: close `FileResponse` in `finally` blocks before `os.unlink` to avoid file descriptor leaks
- [x] Add test for Windows-path stripping via `\\` separators
- [x] Add test for emoji-only name using `download<ext>` fallback
- [x] Verify all logic changes with inline Python