### PR TITLE
docs(cursor): require release bump before release branch

### DIFF
--- a/.cursor/rules/changelog-best-practices.mdc
+++ b/.cursor/rules/changelog-best-practices.mdc
@@ -139,7 +139,7 @@ Documentation changes should be grouped under the **Documentation** category, no
 
 ## Release Process
 
-Follow **CONTRIBUTING.md §7 (Releasing for maintainers)** (Git Flow: `release/*` branch). Prefer **`python3 scripts/prepare_release_bump.py`** `patch`|`minor`|`major`, which applies the `## [Unreleased]  <!-- release -->` marker (see `.bumpversion.cfg`), runs **bump2version**, **`scripts/fix_changelog_after_bump.py`**, and inserts an empty `## [Unreleased]` for the next cycle. Contributors use plain `## [Unreleased]` until the maintainer runs the script.
+Follow **CONTRIBUTING.md §7 (Releasing for maintainers)** (Git Flow: `release/*` branch). Maintainers **must run** **`python3 scripts/prepare_release_bump.py`** `patch`|`minor`|`major` before creating/pushing a `release/*` branch. The script applies the `## [Unreleased]  <!-- release -->` marker (see `.bumpversion.cfg`), runs **bump2version**, **`scripts/fix_changelog_after_bump.py`**, and inserts an empty `## [Unreleased]` for the next cycle. Contributors use plain `## [Unreleased]` until the maintainer runs the script.
 
 During releases, maintainers also:
 1. Review and consolidate entries moved under the new version

--- a/.cursor/rules/git-flow-workflow.mdc
+++ b/.cursor/rules/git-flow-workflow.mdc
@@ -28,6 +28,8 @@ This project follows **strict Git Flow**. All changes must follow the branching 
 - Feature branches **must** target `develop`
 - Hotfix branches **must** target `main`
 - Release branches merge into both `main` and `develop`
+- Before creating any `release/*` branch, maintainers **must** run `python3 scripts/prepare_release_bump.py` with `patch`, `minor`, or `major`
+- Create the `release/*` branch only after the bump script updates release artifacts (`CHANGELOG.md`, `VERSION`, and related versioned files)
 
 ## Examples
 
@@ -45,5 +47,6 @@ git checkout -b hotfix/critical-security-patch
 # Release branch (maintainers only)
 git checkout develop
 git pull origin develop
+python3 scripts/prepare_release_bump.py patch
 git checkout -b release/v0.2.1
 ```


### PR DESCRIPTION
## Description

Aligns Cursor rules with the maintainer release workflow: a `release/*` branch must only be created **after** running `python3 scripts/prepare_release_bump.py` with `patch`, `minor`, or `major`, so `CHANGELOG.md`, `VERSION`, and related versioned files are updated in one step.

## Related Issue

N/A (process/tooling docs only).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [ ] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

- **`.cursor/rules/git-flow-workflow.mdc`**: Document that maintainers must run `prepare_release_bump.py` before creating any `release/*` branch; extend the release example to include the script.
- **`.cursor/rules/changelog-best-practices.mdc`**: State that maintainers **must run** the script before creating/pushing a `release/*` branch (replacing softer “prefer” wording).

## Testing

- [x] All existing tests pass (not applicable—markdown rule files only)
- [ ] New tests added (if applicable)
- [ ] Manual testing completed (if applicable)

**Test commands:**

```bash
pytest
```

## Checklist

### Code Quality

- [x] Documentation-only change to Cursor rules

### Git / PR

- [x] Commit message follows conventional commits
- [x] Branch targets `develop`
