### PR TITLE
chore(scripts): require venv for prepare_release_bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+### Changed
+
+- **Release tooling**: `scripts/prepare_release_bump.py` exits unless run inside a Python virtual environment (with dependencies from `pip install -r requirements.txt`), so maintainers do not hit a missing `bump2version` when using the system interpreter.
+
 ### Fixed
 
 - **Metadata session download headers**: File download responses now set standards-compliant `Content-Disposition` with both `filename` (ASCII fallback) and `filename*` (RFC5987 UTF-8), expose `Content-Disposition` to browser JS via `Access-Control-Expose-Headers`, and return a real MIME type (with fallback to `application/octet-stream`) instead of a generic `file` content type.

--- a/scripts/prepare_release_bump.py
+++ b/scripts/prepare_release_bump.py
@@ -7,7 +7,9 @@
 3. Runs ``fix_changelog_after_bump.py`` (release date, indent cleanup).
 4. Inserts an empty ``## [Unreleased]`` above the new ``## [vX.Y.Z] - …`` heading.
 
-Requires ``bump2version`` on PATH (``pip install -r requirements.txt``).
+Must be run **inside an activated project virtualenv** (or with that venv's
+``python``), after ``pip install -r requirements.txt`` so ``bump2version`` is
+on PATH.
 
 From repo root::
 
@@ -41,6 +43,19 @@ MARKER_HEADING = "## [Unreleased]  <!-- release -->"
 def _fail(msg: str) -> None:
     print(msg, file=sys.stderr)
     sys.exit(1)
+
+
+def _require_venv() -> None:
+    base = getattr(sys, "base_prefix", sys.prefix)
+    if sys.prefix != base:
+        return
+    _fail(
+        "prepare_release_bump.py must run inside a Python virtual environment.\n"
+        "Create and use the project venv, install deps, then retry. Example:\n"
+        "  python3 -m venv .venv && source .venv/bin/activate "
+        "&& pip install -r requirements.txt\n"
+        "  python3 scripts/prepare_release_bump.py patch"
+    )
 
 
 def _find_note_index(text: str) -> int:
@@ -111,7 +126,8 @@ def ensure_empty_unreleased_section(text: str) -> tuple[str, bool]:
 def _run_bump2version(kind: str, allow_dirty: bool) -> None:
     if not shutil.which("bump2version"):
         _fail(
-            "bump2version not found on PATH. Install with: pip install -r requirements.txt"
+            "bump2version not found on PATH. In your project venv run: "
+            "pip install -r requirements.txt"
         )
     cmd = ["bump2version", kind]
     if allow_dirty:
@@ -160,6 +176,7 @@ def main() -> None:
     args = parser.parse_args()
     allow_dirty = not args.no_allow_dirty
 
+    _require_venv()
     _warn_branch()
     raw = CHANGELOG_PATH.read_text()
     updated, changed = ensure_bump_marker(raw)


### PR DESCRIPTION
## Description

`scripts/prepare_release_bump.py` now fails fast unless it is run with a Python interpreter that is inside a virtual environment (`sys.prefix != sys.base_prefix`). That matches the intended workflow (project venv + `pip install -r requirements.txt`, which provides `bump2version` on `PATH`). `--help` still works with the system interpreter.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [x] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

- **`scripts/prepare_release_bump.py`**: Add `_require_venv()`, call it after argument parsing; docstring and `bump2version` missing message updated.
- **`CHANGELOG.md`**: Entry under `[Unreleased]` → **Changed** → release tooling.

## Testing

- [x] `python3 scripts/prepare_release_bump.py --help` succeeds without a venv
- [x] `python3 scripts/prepare_release_bump.py patch` exits with the new error when not in a venv
- [ ] `pytest` (full suite not re-run for this change)

**Test commands:**

```bash
python3 scripts/prepare_release_bump.py --help
python3 scripts/prepare_release_bump.py patch  # expect failure outside venv
.venv/bin/python scripts/prepare_release_bump.py patch  # expect venv check passes (do not run bump unless ready)
pytest
```

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Commit message follows conventional commits
