### PR TITLE
docs: fix GrowTheMusicTree repo link across docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 - **README**: Added ecosystem context with portfolio links (`themusictree.org`, HearTheMusicTree project page) and clarified that portfolio/marketing source-of-truth lives in `the-music-tree-frontend`.
 
+- **README**: Corrected the GrowTheMusicTree ecosystem link to the `grow-the-music-tree-frontend` repository.
+
 ## [v2.2.3] - 2026-04-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ HearTheMusicTree aims to provide a user-first, extensible platform for organizin
 HearTheMusicTree integrates with other BehindTheMusicTree projects:
 
 - **[AudioMeta Python](https://github.com/BehindTheMusicTree/audiometa)**: Reliable metadata reading and updating across formats (ID3v1, ID3v2, Vorbis, RIFF)
-- **[GrowTheMusicTree](https://github.com/BehindTheMusicTree/grow-the-music-tree)**: Community-driven taxonomy curation for classification and playlist generation
+- **[GrowTheMusicTree](https://github.com/BehindTheMusicTree/grow-the-music-tree-frontend)**: Community-driven taxonomy curation for classification and playlist generation
 - **[TheMusicTreeAPI](https://github.com/BehindTheMusicTree/the-music-tree-api)**: Authoritative RESTful endpoints for genre references, hierarchies, and detection
 
 > **⚠️ Note**: The API is currently undergoing server migration and is not available online. Please set up a local development environment to use the API. See [Getting Started](#getting-started) for setup instructions.

--- a/VISION.md
+++ b/VISION.md
@@ -95,7 +95,7 @@ Find the BehindTheMusicTree organization on GitHub for related projects:
 
 - Organization: https://github.com/BehindTheMusicTree
 - AudioMeta: https://github.com/BehindTheMusicTree/audiometa
-- GrowTheMusicTree: https://github.com/BehindTheMusicTree/grow-the-music-tree
+- GrowTheMusicTree: https://github.com/BehindTheMusicTree/grow-the-music-tree-frontend
 - TheMusicTreeAPI: https://github.com/BehindTheMusicTree/the-music-tree-api
 
 ## 🧭 Contribution Guidelines & Code of Conduct


### PR DESCRIPTION
Updates the README and VISION.md ecosystem sections so the GrowTheMusicTree link points at <a href="https://github.com/BehindTheMusicTree/grow-the-music-tree-frontend">BehindTheMusicTree/grow-the-music-tree-frontend</a> instead of the old `grow-the-music-tree` repository name.

## Related Issue



## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [ ] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

- `README.md`: GrowTheMusicTree href updated to `grow-the-music-tree-frontend`.
- `VISION.md`: GrowTheMusicTree URL updated to `grow-the-music-tree-frontend` for consistency.
- `CHANGELOG.md`: Documented under `[Unreleased]` → Documentation.

## Testing

- [x] All existing tests pass (not required for docs-only change; no code paths affected)
- [ ] New tests added (if applicable)
- [x] Manual verification: link opens the intended GitHub repository

**Test commands:**

```bash
pytest
```

## Checklist

### Code Quality

- [x] N/A for README/CHANGELOG/VISION only

### Tests

- [x] N/A — documentation-only

### Documentation

- [x] README updated
- [x] VISION.md updated
- [x] CHANGELOG.md updated in `[Unreleased]` section

### Git Hygiene

- [x] Commit messages follow convention: `<type>(<scope>): <summary>`
- [x] Branch follows naming convention
- [x] No accidental commits

## Breaking Changes

- [ ] This PR includes breaking changes

## Additional Notes

Pure documentation; safe to merge after review.

## Reviewer Notes

Confirm the canonical repo for GrowTheMusicTree is `grow-the-music-tree-frontend` before merging.