### PR TITLE
docs: align Git Flow branch rules across CONTRIBUTING, CI, and Cursor

### DIFF
--- a/.cursor/rules/git-flow-workflow.mdc
+++ b/.cursor/rules/git-flow-workflow.mdc
@@ -22,6 +22,14 @@ This project follows **strict Git Flow**. All changes must follow the branching 
 2. Include issue numbers when applicable: `feature/123-add-ogg-support`
 3. Be descriptive: `feature/improve-genre-classification`, not `feature/fix`
 
+## Pull Requests to `develop` (enforced in CI)
+
+Allowed **source branch** prefixes only: `feature/`, `chore/`, `dependabot/`, `release/`.
+
+Classic Git Flow uses **`feature/*`** to integrate features and fixes into `develop`. This repository also allows **`chore/*`** (maintenance, documentation, CI), **`dependabot/*`**, and **`release/*`** when merging release work back into `develop`.
+
+Do **not** use other top-level prefixes (e.g. `docs/`, `fix/`, `refactor/`) for the branch name — CI will fail. Use `feature/<topic>` or `chore/<topic>` instead.
+
 ## Important Rules
 
 - **No direct commits** to `main` or `develop` - all changes must go through Pull Requests

--- a/.cursor/rules/pre-pr-checklist.mdc
+++ b/.cursor/rules/pre-pr-checklist.mdc
@@ -37,13 +37,13 @@ Before submitting a Pull Request, ensure all checks are completed. This checklis
 ## Git Hygiene
 
 - ✅ Commit messages follow the commit message convention (see `commit-message-convention.mdc`)
-- ✅ Branch is up to date with target branch (`develop` for features, `main` for hotfixes)
-- ✅ Branch follows naming convention (`feature/`, `chore/`, `hotfix/`, `release/`)
+- ✅ Branch is up to date with target branch (`develop` for `feature/*`, `chore/*`, `dependabot/*`, `release/*`; `main` for `hotfix/*`, `release/*`)
+- ✅ Branch follows naming convention for PRs to `develop`: `feature/`, `chore/`, `dependabot/`, `release/`; for PRs to `main`: `hotfix/`, `release/` (see `git-flow-workflow.mdc` and CONTRIBUTING.md **Branch Protection**)
 - ✅ No accidental commits (large files, secrets, personal configs)
 
 ## Branch Target
 
-- ✅ Feature branches target `develop` branch
+- ✅ `feature/*`, `chore/*`, `dependabot/*`, and `release/*` (when merging into `develop`) target the `develop` branch
 - ✅ Hotfix branches target `main` branch
 - ✅ Release branches target both `main` and `develop` (maintainers only)
 

--- a/.cursor/rules/pull-request-convention.mdc
+++ b/.cursor/rules/pull-request-convention.mdc
@@ -29,11 +29,12 @@ PR titles must follow the same format as commit messages: `<type>(<optional-scop
 
 ## Branch Prefixes vs PR Title Types
 
-Branch prefixes (`feature/`, `chore/`, `hotfix/`) differ from PR title types:
+Branch names use Git Flow prefixes; PR titles use Conventional Commits types — they are not the same. Allowed source branches for PRs to `develop` are `feature/`, `chore/`, `dependabot/`, and `release/` only (no `docs/`, `fix/`, etc.); see `git-flow-workflow.mdc`.
 
 - Branch `feature/add-flac-support` → PR title: `feat: add flac support` (use `feat`, not `feature`)
 - Branch `chore/update-dependencies` → PR title: `chore: update dependencies` (use `chore`)
 - Branch `hotfix/critical-bug` → PR title: `fix: critical bug` (use `fix`, not `hotfix`)
+- Dependabot branches keep the `dependabot/` prefix; PR title is usually left as the bot generated or adjusted per review
 
 ## GitHub Auto-Suggested Titles
 
@@ -55,6 +56,6 @@ Branch prefixes (`feature/`, `chore/`, `hotfix/`) differ from PR title types:
 
 ## Target Branch
 
-- Feature branches target `develop`
+- `feature/*`, `chore/*`, `dependabot/*`, and `release/*` (into `develop`) target `develop`
 - Hotfix branches target `main`
 - Release branches target both `main` and `develop` (maintainers only)

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -40,12 +40,17 @@ jobs:
               echo "❌ Invalid source branch: $SOURCE_BRANCH"
               echo "Pull requests to develop must come from feature/*, chore/*, dependabot/*, or release/* branches only."
               echo ""
+              echo "Classic Git Flow integrates work into develop via feature/*; this repo also allows chore/* (maintenance, docs, CI),"
+              echo "dependabot/* (automation), and release/* (release merges back to develop)."
+              echo "Prefixes such as docs/*, fix/*, or refactor/* are not accepted — use feature/<name> or chore/<name>."
+              echo ""
               echo "Direct PRs from main to develop are not allowed."
-              echo "Examples:"
+              echo "Valid examples:"
               echo " - feature/improve-genre-classification"
               echo " - chore/update-dependencies"
               echo " - dependabot/pip/requests-2.28.0"
-              echo "See CONTRIBUTING.md for Git Flow guidelines."
+              echo " - release/v0.2.1"
+              echo "See CONTRIBUTING.md (Branching, Branch Protection) for Git Flow guidelines and how to fix a wrong branch name."
               exit 1
             fi
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 - **README**: Added ecosystem context with portfolio links (`themusictree.org`, HearTheMusicTree project page) and clarified that portfolio/marketing source-of-truth lives in `the-music-tree-frontend`.
 
+- **Git Flow / branch protection**: CONTRIBUTING and `.cursor/rules/git-flow-workflow.mdc` state how PRs to `develop` relate to classic Git Flow (`feature/*` plus `chore/*`, `dependabot/*`, `release/*`), list disallowed prefixes (e.g. `docs/*`), and describe the usual fix when the branch-name check fails. The branch protection workflow failure message and `docs/workflows.md` point to the same guidance. **Pre-PR checklist** and **pull-request-convention** Cursor rules are aligned (`dependabot/*`, target branches, invalid prefixes).
+
 ## [v2.2.3] - 2026-04-01
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -288,18 +288,30 @@ We follow **strict Git Flow** with the following branch structure:
 
 #### Develop Branch (`develop`)
 
--- The integration branch for ongoing development
--- All feature and chore branches merge into `develop`
+- The integration branch for ongoing development
+- Feature and chore branches merge into `develop` via pull requests
 - `develop` is merged into `main` via release branches
-- **No direct commits allowed** - All changes must go through Pull Requests
--- Only receives merges from `feature/*`, `chore/*`, and `dependabot/*` branches
-- **Branch protection enforced** - GitHub Actions automatically blocks PRs to `develop` that don't come from `feature/*`, `chore/*`, or `dependabot/*` branches (see `.github/workflows/branch-protection.yml`)
+- **No direct commits allowed** — all changes must go through pull requests
+- Pull requests to `develop` are only accepted from `feature/*`, `chore/*`, `dependabot/*`, or `release/*` branches (see **Branch Protection** below)
+- **Branch protection enforced** — GitHub Actions blocks PRs to `develop` that do not use one of those source branch prefixes (see `.github/workflows/branch-protection.yml`)
 
 #### 🛡️ Branch Protection
 
-- **PRs to `main`** must come from `hotfix/*` or `release/*` branches only. This ensures production fixes are traceable and carefully released.
-- **PRs to `develop`** must come from `feature/*`, `chore/*`, or `dependabot/*` branches only. PRs from other branch types (e.g., `fix/*`, `refactor/*`, etc.) will be blocked by the branch protection workflow.
-- Branch protection is enforced by the `branch-protection.yml` GitHub Actions workflow located at `.github/workflows/branch-protection.yml`.
+- **PRs to `main`** must come from `hotfix/*` or `release/*` branches only. This keeps production changes traceable and tied to releases or hotfixes.
+- **PRs to `develop`** must come from `feature/*`, `chore/*`, `dependabot/*`, or `release/*` branches only. Other prefixes (e.g. `docs/*`, `fix/*`, `refactor/*`) fail the **Branch Protection Check / Verify PR source branch** job and cannot be merged while required checks are enabled.
+
+**How this maps to Git Flow:** In the classic model, work is integrated into `develop` through **`feature/*`** branches. This repository also uses **`chore/*`** for maintenance and documentation-only changes, **`dependabot/*`** for dependency automation, and **`release/*`** when merging release-line work back into `develop`.
+
+**If your PR fails the branch name check:**
+
+1. **Rename the branch locally** (on your work branch): `git branch -m feature/<descriptive-name>` or `git branch -m chore/<descriptive-name>`.
+2. **Push the new name** and set upstream: `git push -u origin HEAD`.
+3. **Remove the old remote branch** if you already pushed it: `git push origin --delete <old-branch-name>`.
+4. **Open a new pull request** from the correctly named branch and close the previous one. (GitHub does not reliably let you retarget an existing PR to a differently named head branch.)
+
+If you had not pushed yet, only steps 1–2 and a new PR are needed. Maintainers cannot “approve past” a failing required check without changing branch protection rules or using an admin merge override — the usual fix is a correctly prefixed branch.
+
+- Enforcement lives in the `branch-protection.yml` workflow at `.github/workflows/branch-protection.yml`.
 
 
 #### Feature Branches (`feature/<name>`)
@@ -595,7 +607,7 @@ Before submitting a Pull Request, ensure the following checks are completed:
 - ✅ Commit messages follow the commit message convention
 - ✅ Branch is up to date with target branch (`develop` for features, `main` for hotfixes)
 - ✅ No accidental commits (large files, secrets, personal configs)
-- ✅ Branch follows naming convention (`feature/`, `chore/`, `hotfix/`, `release/`)
+- ✅ Branch follows naming convention (`feature/`, `chore/`, `dependabot/`, `hotfix/`, `release/`) — see **Branching** / **Branch Protection**
 
 **5. Branch Target**
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -122,7 +122,7 @@ Enforces Git Flow: only allows certain source branches for PRs to `main` and `de
 **Logic:**
 
 - **PRs to `main`:** source branch must be `hotfix/*` or `release/*`; otherwise the job fails
-- **PRs to `develop`:** source branch must be `feature/*`, `chore/*`, `dependabot/*`, or `release/*`; otherwise the job fails
+- **PRs to `develop`:** source branch must be `feature/*`, `chore/*`, `dependabot/*`, or `release/*`; otherwise the job fails (classic Git Flow uses `feature/*`; other prefixes here are documented in CONTRIBUTING.md under **Branch Protection**).
 
 **No manual or workflow_call;** runs only on PR open/sync.
 


### PR DESCRIPTION
## Description

Aligns how Git Flow and PR source-branch rules are described everywhere they matter: **CONTRIBUTING.md**, **docs/workflows.md**, the **branch protection** workflow failure output, and **Cursor rules** (`git-flow-workflow.mdc`, `pre-pr-checklist.mdc`, `pull-request-convention.mdc`).

Classic Git Flow integrates into `develop` via `feature/*`; this repo also allows `chore/*`, `dependabot/*`, and `release/*` for PRs to `develop`. Invalid prefixes such as `docs/*` are explicitly called out. CONTRIBUTING now documents the usual remediation when **Verify PR source branch** fails.

**CI behavior is unchanged** (same allowed regex); only messages and documentation were updated, plus Cursor rule alignment.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [ ] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [x] 🧹 Chore/maintenance (Cursor rules + CI copy)

## Target Branch

- [x] `develop`
- [ ] `main`

## Changes Made

- `.github/workflows/branch-protection.yml`: Clearer failure text (Git Flow mapping, invalid prefixes, `release/*` example, pointer to CONTRIBUTING).
- `CONTRIBUTING.md`: Fixed `develop` section typos; documented allowed source branches including `release/*`; **Branch Protection** expanded with Git Flow mapping and steps when the check fails; pre-PR checklist branch line aligned.
- `docs/workflows.md`: Short cross-reference to CONTRIBUTING for Git Flow context.
- `.cursor/rules/git-flow-workflow.mdc`: PRs to `develop` prefixes, classic vs repo extensions, disallowed prefixes.
- `.cursor/rules/pre-pr-checklist.mdc`: Branch naming and targets match CI (`dependabot/*`, `release/*`).
- `.cursor/rules/pull-request-convention.mdc`: Branch prefixes vs PR titles; allowed `develop` source branches; target branch list.
- `CHANGELOG.md`: `[Unreleased]` Documentation entry.

## Testing

- [x] No runtime code changes
- [ ] `pytest` (optional sanity)

**Test commands:**

```bash
pytest
```

## Checklist

### Documentation

- [x] CONTRIBUTING / workflows / CHANGELOG updated
- [x] Cursor rules aligned with CONTRIBUTING and CI

### Git Hygiene

- [x] Commit: `docs: align Git Flow branch rules across CONTRIBUTING, CI, and Cursor`
- [x] Branch: `chore/align-gitflow-docs-ci-cursor-rules`

## Breaking Changes

- [ ] None

## Additional Notes

After merge, contributors using invalid branch prefixes will see clearer CI output and matching guidance in CONTRIBUTING and Cursor.
