### PR TITLE
chore(config): remove LIBRARIES_DIR_NAME and use LIBRARIES_DIR only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ env:
   TMP_UPLOADED_FILES: /tmp/ci-uploaded/
   METADATA_SESSION_DIR: /tmp/ci-metadata-sessions/
   MEDIA_DIR: /tmp/ci-media/
-  LIBRARIES_DIR_NAME: libraries
   LIBRARIES_DIR: /tmp/ci-media/libraries/
 
   DB_IS_NEEDED: true
@@ -41,7 +40,7 @@ jobs:
   pre-commit:
     name: Pre-commit
     runs-on: ubuntu-latest
-    # Dummy identity + flags only. Inherits workflow paths for FILE_UPLOAD (models need MEDIA_ROOT / LIBRARIES_DIR_NAME at import).
+    # Dummy identity + flags only. Inherits workflow paths for FILE_UPLOAD (models need LIBRARIES_DIR at import).
     # No GitHub Environment or secrets: DB and external integrations off for mypy-only Django load.
     env:
       APP_NAME: htmt_api_mypy_ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 - **Pre-commit cache persistence (Docker Compose)**: `api` now sets `PRE_COMMIT_HOME` and mounts a named volume (`api-pre-commit-cache`) at that path so pre-commit hook environments are reused across container recreations instead of re-initializing on each commit.
 
+- **Library path env contract**: Removed runtime usage of `LIBRARIES_DIR_NAME`; settings and user library path generation now rely on `LIBRARIES_DIR` only. Updated Compose defaults, test workflow env, and dev env example accordingly.
+
 ### CI
 
 - **Test workflow**: Workflow-level `STATIC_FILES` and `STATIC_FILES_URL` are omitted so Django uses `STATIC_FILES_STATE` `NOT_NEEDED` in CI (migrate/pytest/pre-commit); API tests do not rely on static file serving (`urls.py` only adds static routes when collecting/serving).

--- a/api/model/user/User.py
+++ b/api/model/user/User.py
@@ -47,13 +47,13 @@ class User(AbstractUser, BaseModel):
         expression=ConditionalExpression(
             condition_field=Fields.IS_TEST_USER,
             when_true=ConcatOp(
-                Value(str(settings.LIBRARIES_DIR_NAME)),
+                Value(str(settings.LIBRARIES_DIR.name)),
                 Value("/"),
                 Value(settings.TEST_USER_LIBRARIES_DIR_NAME_PREFIXE),
                 F(Fields.ID),
             ),
             when_false=ConcatOp(
-                Value(str(settings.LIBRARIES_DIR_NAME)),
+                Value(str(settings.LIBRARIES_DIR.name)),
                 Value("/"),
                 Value(settings.USER_LIBRARIES_DIR_NAME_PREFIXE),
                 F(Fields.ID),

--- a/api/settings.py
+++ b/api/settings.py
@@ -98,7 +98,6 @@ AFP_ENABLED: bool
 MUSICBRAINZ_LOOKUP_ENABLED: bool
 MEDIA_ROOT: Path
 MEDIA_URL: str
-LIBRARIES_DIR_NAME: str
 LIBRARIES_DIR: Path
 
 # Data
@@ -804,11 +803,8 @@ def setup_media_dirs():
         global MEDIA_URL
         MEDIA_URL = load_required_str_env_var("MEDIA_URL")
 
-    global LIBRARIES_DIR_NAME
-    LIBRARIES_DIR_NAME = load_required_str_env_var("LIBRARIES_DIR_NAME")
-
     global LIBRARIES_DIR
-    LIBRARIES_DIR = MEDIA_ROOT / LIBRARIES_DIR_NAME
+    LIBRARIES_DIR = load_required_path_env_var("LIBRARIES_DIR")
     print_django("LIBRARIES_DIR: " + str(LIBRARIES_DIR))
     if not LIBRARIES_DIR.is_dir():
         raise OSError(
@@ -868,7 +864,7 @@ else:
     STATIC_FILES = os.getenv("STATIC_FILES")
     if ENV == "collect_static":
         STATIC_FILES_STATE = StaticFileStates.COLLECTING
-        LIBRARIES_DIR_NAME = ""  # Needed to setup the database (User model)
+        LIBRARIES_DIR = Path()  # Needed to setup the database (User model)
         setup_static_files()
     elif not STATIC_FILES:
         print_django("Static files are not needed.")
@@ -905,7 +901,7 @@ else:
             "ACOUSTID_API_KEY",
             "MEDIA_DIR",
             "METADATA_SESSION_DIR",
-            "LIBRARIES_DIR_NAME",
+            "LIBRARIES_DIR",
             "TMP_UPLOADED_FILES",
         ]:
             if os.getenv(var_name):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,6 @@ services:
       TMP_UPLOADED_FILES: ${TMP_UPLOADED_FILES:-/tmp/uploaded-files/}
       METADATA_SESSION_DIR: ${METADATA_SESSION_DIR:-/tmp/metadata-sessions/}
       MEDIA_DIR: ${MEDIA_DIR:-/tmp/htmt-media}
-      LIBRARIES_DIR_NAME: ${LIBRARIES_DIR_NAME:-libraries}
       LIBRARIES_DIR: ${LIBRARIES_DIR:-/tmp/htmt-media/libraries}
       DJANGO_LOG_DIR: ${DJANGO_LOG_DIR:-/var/log/django/}
       DJANGO_LOG_GENERAL_FILENAME: ${DJANGO_LOG_GENERAL_FILENAME:-general.log}

--- a/env/dev/.env.compose.dev.example
+++ b/env/dev/.env.compose.dev.example
@@ -23,7 +23,6 @@ FILE_UPLOAD_ENABLED=true
 TMP_UPLOADED_FILES=/tmp/uploaded-files/
 METADATA_SESSION_DIR=/tmp/metadata-sessions/
 MEDIA_DIR=/tmp/htmt-media
-LIBRARIES_DIR_NAME=libraries
 LIBRARIES_DIR=/tmp/htmt-media/libraries
 
 DJANGO_LOG_DIR=/var/log/django/


### PR DESCRIPTION
## Description

This PR removes `LIBRARIES_DIR_NAME` from the runtime env contract and uses `LIBRARIES_DIR` as the single source of truth for library path configuration.

Main outcomes:
- Fixes staging startup failures caused by missing `LIBRARIES_DIR_NAME` despite a valid `LIBRARIES_DIR`.
- Simplifies env configuration by removing redundant path components.
- Keeps user library path generation consistent by deriving the folder name from `LIBRARIES_DIR`.

## Related Issue

<!-- Link when filed -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [x] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [x] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [x] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

- **Runtime settings**
  - `api/settings.py` no longer reads `LIBRARIES_DIR_NAME`.
  - `LIBRARIES_DIR` is now loaded directly from env and validated as required when uploads are enabled.
  - `FILE_UPLOAD_ENABLED=false` validation now rejects `LIBRARIES_DIR` (instead of `LIBRARIES_DIR_NAME`).

- **Model path generation**
  - `api/model/user/User.py` now builds `lib_path_relative_to_media` using `settings.LIBRARIES_DIR.name`.
  - This preserves relative paths while removing the separate `LIBRARIES_DIR_NAME` dependency.

- **Environment/workflow alignment**
  - Removed `LIBRARIES_DIR_NAME` from:
    - `docker-compose.yml`
    - `env/dev/.env.compose.dev.example`
    - `.github/workflows/test.yml`
  - Updated test workflow comment to reflect `LIBRARIES_DIR`-only contract.

- **Documentation**
  - Added `CHANGELOG.md` `[Unreleased]` entry describing the `LIBRARIES_DIR`-only contract.

## Testing

- Verified by static inspection of all `LIBRARIES_DIR_NAME` runtime references.
- Verified env surface updates are consistent across Compose/dev example/test workflow.

**Test commands:**

```bash
# Optional local verification
docker compose up -d --force-recreate api
docker compose exec -T api python3 manage.py check
```

## Checklist

### Code Quality

- [x] Code follows project style guidelines ([code-style.md](code-style.md))
- [x] Code follows Django best practices
- [x] Type hints added where appropriate
- [x] No debug statements or commented-out code
- [x] One class per file (if applicable)
- [x] Field name constants used (if applicable)

### Tests

- [ ] Relevant tests pass for fixed behavior
- [ ] New tests added (if applicable)
- [ ] Manual testing completed (if applicable)

### Documentation

- [x] Docstrings updated (only when needed)
- [ ] README updated (if applicable)
- [x] CHANGELOG.md updated in `[Unreleased]` section
- [x] Type hints added/updated

### Git Hygiene

- [x] Commit messages follow convention: `<type>(<scope>): <summary>`
- [ ] Branch is up to date with target branch
- [x] Branch follows naming convention (`feature/`, `chore/`, `dependabot/`, `hotfix/`, `release/`)
- [x] No accidental commits (large files, secrets, personal configs)

## Breaking Changes

- [ ] This PR includes breaking changes
- [ ] Breaking changes are documented in the description above

None expected.

## Screenshots (if applicable)

N/A

## Additional Notes

This PR focuses specifically on removing `LIBRARIES_DIR_NAME` from runtime env requirements and aligning dependent config surfaces.

## Reviewer Notes

- Validate startup in staging with only `LIBRARIES_DIR` (no `LIBRARIES_DIR_NAME`).
- Confirm user library relative path generation remains stable for existing users.
