### PR TITLE
fix(cors): load allowed origins from environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ All contributors (including maintainers) should update `CHANGELOG.md` when creat
 
 ## [Unreleased]
 
+### Fixed
+
+- **CORS configuration** ([`api/settings.py`](api/settings.py)): When `APP_IS_EXPOSED=true`, `CORS_ALLOWED_ORIGINS` is now loaded from a required `CORS_ALLOWED_ORIGINS` env var (comma-separated, same validation pattern as `CSRF_TRUSTED_ORIGINS`/`ALLOWED_HOSTS`), restoring Django-level CORS handling that was silently dropped when the nginx gateway was replaced by Traefik/Coolify. Companion `infrastructure` change supplies the env var via Ansible.
+
 ## [v2.2.8] - 2026-06-19
 
 ### Changed

--- a/api/settings.py
+++ b/api/settings.py
@@ -330,7 +330,20 @@ def setup_app_exposure_if_needed():
         else:
             raise OSError("The app is exposed but no allowed hosts are set.")
 
-        print_django("CORS_ALLOW_ALL_ORIGINS is not set as a web server interface is used to handle CORS.")
+        CORS_ALLOWED_ORIGINS_STR = load_required_str_env_var("CORS_ALLOWED_ORIGINS")
+        print_django(f"CORS_ALLOWED_ORIGINS env variable: {CORS_ALLOWED_ORIGINS_STR}")
+        global CORS_ALLOWED_ORIGINS
+        CORS_ALLOWED_ORIGINS = CORS_ALLOWED_ORIGINS_STR.split(",")
+        for cors_allowed_origin in CORS_ALLOWED_ORIGINS:
+            cors_allowed_origin = cors_allowed_origin.strip()
+            if cors_allowed_origin == "":
+                raise ValueError("A CORS allowed origin is empty.")
+        if len(CORS_ALLOWED_ORIGINS) > 0:
+            print_django("CORS is allowed for the following origin(s):")
+            for cors_allowed_origin in CORS_ALLOWED_ORIGINS:
+                print_django(str(cors_allowed_origin))
+        else:
+            raise OSError("The app is exposed but no CORS allowed origins are set.")
     else:
         ALLOWED_HOSTS = [
             "127.0.0.1",


### PR DESCRIPTION
## PR body

## Description

When the app is exposed (`APP_IS_EXPOSED=true`), `api/settings.py` used to just log that CORS was left to the web server interface and never set Django's `CORS_ALLOWED_ORIGINS`. This silently dropped CORS handling when the nginx gateway (which used to inject `Access-Control-Allow-Origin`) was replaced by Traefik/Coolify, so cross-origin requests from frontends got no CORS header at all.

This PR makes Django load `CORS_ALLOWED_ORIGINS` from a required env var, following the same comma-separated/strip/empty-check pattern already used for `CSRF_TRUSTED_ORIGINS` and `ALLOWED_HOSTS` just above it in the same function.

It's the API-side counterpart to the infrastructure fix that re-introduces `CORS_ALLOWED_ORIGINS` via Ansible (`group_vars/all.yml`, built from the `audiometa_front_subdomain`/`gtmt_front_subdomain`/`htmt_front_subdomain` GitHub Variables) — the two should land together.

## Related Issue

<!-- None referenced -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update
- [x] 🔧 Configuration change
- [ ] 🎨 Style/formatting changes
- [ ] 🧹 Chore/maintenance

## Target Branch

- [x] `develop` (for features, bug fixes, chores, dependency updates from Dependabot)
- [ ] `main` (for hotfixes only)

## Changes Made

- [api/settings.py](api/settings.py): in `setup_app_exposure_if_needed`, when `APP_IS_EXPOSED=true`, replaced the log-only message with actual loading of `CORS_ALLOWED_ORIGINS` from a required env var, split on `,`, validated for empty entries, and raises `OSError` if none are configured — mirroring the existing `CSRF_TRUSTED_ORIGINS`/`ALLOWED_HOSTS` handling.

## Testing

No automated test currently covers `setup_app_exposure_if_needed`; this was verified by inspection against the sibling `CSRF_TRUSTED_ORIGINS`/`ALLOWED_HOSTS` blocks it mirrors.

- [ ] All existing tests pass
- [ ] New tests added (if applicable)
- [ ] Manual testing completed (if applicable)

**Test commands:**
```bash
# Exposed app with origins set — should start and log the allowed origins
APP_IS_EXPOSED=true CORS_ALLOWED_ORIGINS="https://example.com" python manage.py check

# Exposed app without origins set — should fail fast (OSError/ValueError)
APP_IS_EXPOSED=true python manage.py check
```

## Checklist

### Code Quality
- [x] Code follows project style guidelines ([code-style.md](code-style.md))
- [x] Code follows Django best practices
- [x] Type hints added where appropriate
- [x] No debug statements or commented-out code
- [ ] One class per file (if applicable)
- [ ] Field name constants used (if applicable)

### Tests
- [ ] All tests pass: `pytest`
- [ ] New features have corresponding tests
- [ ] Bug fixes include regression tests
- [ ] Tests follow naming convention: `test_{scenario}_then_{expected_result}`
- [ ] Each test focuses on a single scenario

### Documentation
- [ ] Docstrings updated (only when needed)
- [ ] README updated (if applicable)
- [ ] CHANGELOG.md updated in `[Unreleased]` section — see proposed entry below
- [x] Type hints added/updated

### Git Hygiene
- [x] Commit messages follow convention: `<type>(<scope>): <summary>`
- [x] Branch is up to date with target branch
- [x] Branch follows naming convention (`feature/`, `chore/`, `dependabot/`, `hotfix/`, `release/`)
- [x] No accidental commits (large files, secrets, personal configs)

## Breaking Changes

- [x] This PR includes breaking changes
- [x] Breaking changes are documented in the description above
- [x] Migration path provided (if applicable)

**Breaking Changes:**
- In any environment with `APP_IS_EXPOSED=true`, `CORS_ALLOWED_ORIGINS` is now a required env var — startup raises `ValueError`/`OSError` if it is unset or contains an empty entry. The companion `infrastructure` repo change (Ansible `group_vars/all.yml`) already provides it for staging/prod; this should not be deployed ahead of that change.

## Screenshots (if applicable)

<!-- Not applicable — backend configuration change -->

## Additional Notes

Companion fix to the `infrastructure` repo, which restores `CORS_ALLOWED_ORIGINS` after it was dropped when the nginx gateway was replaced by Traefik/Coolify.

## Reviewer Notes

Please confirm `CORS_ALLOWED_ORIGINS` is set in every environment where `APP_IS_EXPOSED=true` before/while this merges, otherwise the app will fail to start there.

---

## Changelog entry to add

`CHANGELOG.md` has an empty `## [Unreleased]` section (no entry for this branch yet). Proposed addition, pending confirmation:

```markdown
## [Unreleased]

### Fixed

- **CORS configuration** ([`api/settings.py`](api/settings.py)): When `APP_IS_EXPOSED=true`, `CORS_ALLOWED_ORIGINS` is now loaded from a required `CORS_ALLOWED_ORIGINS` env var (comma-separated, same validation pattern as `CSRF_TRUSTED_ORIGINS`/`ALLOWED_HOSTS`), restoring Django-level CORS handling that was silently dropped when the nginx gateway was replaced by Traefik/Coolify. Companion `infrastructure` change supplies the env var via Ansible.
```
